### PR TITLE
Stop checking encoding names

### DIFF
--- a/lib/secret_service/secret.rb
+++ b/lib/secret_service/secret.rb
@@ -48,7 +48,7 @@ class Secret
   def sniff_content_type str
     if (str.nil? or
         (not str.respond_to? :encoding ) or
-        (str.encoding.to_s == "ASCII-8BIT"))
+        (str.encoding == Encoding::BINARY))
       "application/octet-stream"
     else
       "text/plain; charset=#{str.encoding}"


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576